### PR TITLE
Adding ability to use SSL/TLS cafile

### DIFF
--- a/connector.py
+++ b/connector.py
@@ -27,7 +27,7 @@ if config.get_mqtt_broker_use_auth():
     password = config.get_mqtt_broker_password()
 
 mqtt = MqttConnection(config.get_mqtt_broker_address(), config.get_mqtt_broker_port(), username, password,
-                      event_handler)
+                      event_handler, config.get_mqtt_client_cafile())
 if not mqtt.start_connection():
     exit(1)
 

--- a/connector.py
+++ b/connector.py
@@ -27,7 +27,7 @@ if config.get_mqtt_broker_use_auth():
     password = config.get_mqtt_broker_password()
 
 mqtt = MqttConnection(config.get_mqtt_broker_address(), config.get_mqtt_broker_port(), username, password,
-                      event_handler, config.get_mqtt_client_cafile())
+        config.get_mqtt_client_cafile(), event_handler)
 if not mqtt.start_connection():
     exit(1)
 

--- a/helper/config.py
+++ b/helper/config.py
@@ -8,6 +8,7 @@ class Config:
         self.port = int(os.getenv('MQTT_PORT', 1883))
         self.user = os.getenv('MQTT_USER', False)
         self.password = os.getenv('MQTT_PASSWORD', False)
+        self.cafile = os.getenv('MQTT_CAFILE', None)
 
     def get_mqtt_broker_address(self):
         return self.addr
@@ -23,3 +24,6 @@ class Config:
 
     def get_mqtt_broker_password(self):
         return self.password
+
+    def get_mqtt_client_cafile(self):
+        return self.cafile

--- a/helper/mqtt.py
+++ b/helper/mqtt.py
@@ -13,7 +13,7 @@ class MqttConnectionCallback:
 
 class MqttConnection:
 
-    def __init__(self, ip, port, username, password, connection_callback, cafile):
+    def __init__(self, ip, port, username, password, cafile, connection_callback):
         self.logger = logging.getLogger("mqtt")
 
         self.mqtt = Client()

--- a/helper/mqtt.py
+++ b/helper/mqtt.py
@@ -13,12 +13,15 @@ class MqttConnectionCallback:
 
 class MqttConnection:
 
-    def __init__(self, ip, port, username, password, connection_callback):
+    def __init__(self, ip, port, username, password, connection_callback, cafile):
         self.logger = logging.getLogger("mqtt")
 
         self.mqtt = Client()
         if username is not None:
             self.mqtt.username_pw_set(username, password)
+
+        if cafile is not None:
+            self.mqtt.tls_set(ca_certs=cafile)
 
         self.mqtt.will_set("chromecast/maintenance/_bridge/online", payload="false", retain=True)
 


### PR DESCRIPTION
Hey!
Love the work you have done on all this, thankyou!
I recently added the ability to use this over SSL/TLS by defining a cafile as a environment variable. Hopefully its useful to someone else?

It can be used like so:
`MQTT_HOST=<hostname> MQTT_PORT=8883 MQTT_CAFILE=ca.crt python3 connector.py`
